### PR TITLE
Ums validation updates

### DIFF
--- a/scripts/ontology_to_txt.py
+++ b/scripts/ontology_to_txt.py
@@ -107,7 +107,7 @@ def processtypes_to_txt(process_file):
         sub_process_of = []
         for parent in g.objects(cls, RDFS.subClassOf):
             parent_name = local_name(str(parent))
-            if parent_name != "ProcessType" and parent_name != "Process":
+            if parent_name != "Process":
                 sub_process_of.append(parent_name)
 
         processes.append({

--- a/tests/test_processtype_consistency.py
+++ b/tests/test_processtype_consistency.py
@@ -1,0 +1,145 @@
+"""Structural consistency checks on the compiled water ontology.
+
+Two invariants are asserted, complementing the SHACL validation tests:
+
+1. Every process class — anything named `watr:Process-*` or used as
+   `sh:class` on `watr:hasProcess` — must reach `watr:Process` via
+   `rdfs:subClassOf+`.
+2. For every device NodeShape that constrains a property path with
+   `sh:class`, the required class must be a (transitive) subclass of the
+   class required by any ancestor device class on the same path
+   (e.g. `BiologicalAeratedFilter.hasProcess` must be a subclass of
+   `Filter.hasProcess`'s required class).
+"""
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+from rdflib import Graph, Namespace, RDFS, SH
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WATER_TTL = ROOT / "libraries" / "water.ttl"
+WATR = Namespace("urn:nawi-water-ontology#")
+PROCESS = WATR.Process
+
+
+def _qname(g: Graph, uri) -> str:
+    try:
+        prefix, _, local = g.compute_qname(uri)
+        return f"{prefix}:{local}"
+    except Exception:
+        return str(uri)
+
+
+def _transitive_superclasses(g: Graph, cls) -> set:
+    seen = set()
+    stack = [cls]
+    while stack:
+        current = stack.pop()
+        for parent in g.objects(current, RDFS.subClassOf):
+            if parent in seen or parent == cls:
+                continue
+            seen.add(parent)
+            stack.append(parent)
+    return seen
+
+
+def _is_subclass_of(g: Graph, child, parent) -> bool:
+    if child == parent:
+        return True
+    return parent in _transitive_superclasses(g, child)
+
+
+def _collect_class_constraints(g: Graph) -> dict:
+    """Return {device_class: {path: set(required_classes)}}."""
+    constraints = defaultdict(lambda: defaultdict(set))
+    for shape, _, prop in g.triples((None, SH.property, None)):
+        path = g.value(prop, SH.path)
+        cls = g.value(prop, SH["class"])
+        if path is None or cls is None:
+            continue
+        constraints[shape][path].add(cls)
+    return constraints
+
+
+def _collect_process_classes(g: Graph) -> set:
+    """Anything named watr:Process-* or used as sh:class on watr:hasProcess."""
+    candidates = set()
+    watr_str = str(WATR)
+    for s in set(g.subjects()):
+        s_str = str(s)
+        if s_str.startswith(watr_str) and s_str[len(watr_str):].startswith("Process-"):
+            candidates.add(s)
+    for _, _, prop in g.triples((None, SH.property, None)):
+        if g.value(prop, SH.path) == WATR.hasProcess:
+            cls = g.value(prop, SH["class"])
+            if cls is not None:
+                candidates.add(cls)
+    candidates.discard(PROCESS)
+    return candidates
+
+
+@pytest.fixture(scope="module")
+def water_graph() -> Graph:
+    g = Graph()
+    g.parse(WATER_TTL, format="ttl")
+    return g
+
+
+def test_all_processes_are_subclass_of_process(water_graph: Graph) -> None:
+    violations = []
+    for cls in sorted(_collect_process_classes(water_graph), key=str):
+        if PROCESS not in _transitive_superclasses(water_graph, cls):
+            parents = list(water_graph.objects(cls, RDFS.subClassOf))
+            violations.append((cls, parents))
+
+    if not violations:
+        return
+
+    lines = [
+        f"{len(violations)} process class(es) are NOT rdfs:subClassOf* {_qname(water_graph, PROCESS)}:"
+    ]
+    for cls, parents in violations:
+        parents_str = (
+            ", ".join(_qname(water_graph, p) for p in parents)
+            if parents
+            else "(no rdfs:subClassOf declared)"
+        )
+        lines.append(f"- {_qname(water_graph, cls)}")
+        lines.append(f"    direct parents: {parents_str}")
+    pytest.fail("\n".join(lines))
+
+
+def test_subclass_shacl_constraints_are_consistent(water_graph: Graph) -> None:
+    constraints = _collect_class_constraints(water_graph)
+    violations = []
+
+    for device_cls, paths in constraints.items():
+        ancestors = _transitive_superclasses(water_graph, device_cls)
+        for path, required_classes in paths.items():
+            for ancestor in ancestors:
+                ancestor_required = constraints.get(ancestor, {}).get(path)
+                if not ancestor_required:
+                    continue
+                for child_cls in required_classes:
+                    for anc_cls in ancestor_required:
+                        if not _is_subclass_of(water_graph, child_cls, anc_cls):
+                            violations.append((device_cls, ancestor, path, child_cls, anc_cls))
+
+    if not violations:
+        return
+
+    lines = [f"{len(violations)} sh:class constraint inconsistency(ies):"]
+    for device, ancestor, path, child_cls, anc_cls in violations:
+        lines.append(
+            f"- {_qname(water_graph, device)} (subClassOf* {_qname(water_graph, ancestor)})"
+        )
+        lines.append(f"    path: {_qname(water_graph, path)}")
+        lines.append(f"    requires: {_qname(water_graph, child_cls)}")
+        lines.append(f"    but ancestor requires: {_qname(water_graph, anc_cls)}")
+        lines.append(
+            f"    -> {_qname(water_graph, child_cls)} is NOT rdfs:subClassOf* "
+            f"{_qname(water_graph, anc_cls)}"
+        )
+    pytest.fail("\n".join(lines))

--- a/tests/test_processtype_consistency.py
+++ b/tests/test_processtype_consistency.py
@@ -1,27 +1,38 @@
 """Structural consistency checks on the compiled water ontology.
 
-Two invariants are asserted, complementing the SHACL validation tests:
+Complements the SHACL validation tests by asserting one structural invariant:
 
-1. Every process class — anything named `watr:Process-*` or used as
-   `sh:class` on `watr:hasProcess` — must reach `watr:Process` via
-   `rdfs:subClassOf+`.
-2. For every device NodeShape that constrains a property path with
-   `sh:class`, the required class must be a (transitive) subclass of the
-   class required by any ancestor device class on the same path
-   (e.g. `BiologicalAeratedFilter.hasProcess` must be a subclass of
-   `Filter.hasProcess`'s required class).
+For every equipment class that constrains ``watr:hasProcess``, and for every
+process required by any of its ancestor equipment classes, at least one of the
+equipment's own required processes must be the same as, or a (transitive)
+subclass of, that ancestor-required process. In other words, a subclass may
+only *refine* (never contradict) the process rules it inherits
+(e.g. ``BiologicalAeratedFilter.hasProcess`` must be a subclass of
+``Filter.hasProcess``'s required class).
+
+An equipment may pin more than one process (e.g. ``MembraneBioreactor`` requires
+both a filtration and a biofiltration process); each ancestor-required process
+just needs to be refined by *one* of them.
+
+Process rules are read from both the legacy shape (``sh:class`` directly on the
+``hasProcess`` property shape) and the qualified-cardinality shape
+(``sh:qualifiedValueShape`` carrying ``sh:class`` or an ``sh:in`` list).
 """
-from collections import defaultdict
+import sys
 from pathlib import Path
 
 import pytest
-from rdflib import Graph, Namespace, RDFS, SH
+from rdflib import Graph, Namespace, URIRef
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WATER_TTL = ROOT / "libraries" / "water.ttl"
 WATR = Namespace("urn:nawi-water-ontology#")
-PROCESS = WATR.Process
+
+# Reuse the consistency helpers from the standalone script unchanged.
+sys.path.insert(0, str(ROOT / "scripts"))
+
+CACHE = {}
 
 
 def _qname(g: Graph, uri) -> str:
@@ -32,52 +43,84 @@ def _qname(g: Graph, uri) -> str:
         return str(uri)
 
 
-def _transitive_superclasses(g: Graph, cls) -> set:
-    seen = set()
-    stack = [cls]
-    while stack:
-        current = stack.pop()
-        for parent in g.objects(current, RDFS.subClassOf):
-            if parent in seen or parent == cls:
-                continue
-            seen.add(parent)
-            stack.append(parent)
-    return seen
+def _find_equipments(g: Graph):
+    """Return a set of all equipment classes."""
+    q = """
+    PREFIX watr: <urn:nawi-water-ontology#>
+    PREFIX s223: <http://data.ashrae.org/standard223#>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+    SELECT DISTINCT ?cls WHERE {
+        ?cls a watr:Class .
+        ?cls rdfs:subClassOf* s223:Equipment .
+    }
+    """
+    if 'equipments' not in CACHE:
+        CACHE['equipments'] = set(row.cls for row in g.query(q))
+    return CACHE['equipments']
 
 
-def _is_subclass_of(g: Graph, child, parent) -> bool:
-    if child == parent:
-        return True
-    return parent in _transitive_superclasses(g, child)
+def _find_process_of_equip(equip_cls: URIRef, g: Graph):
+    """Return the set of process classes required by an equipment via watr:hasProcess.
+
+    Handles the legacy shape (``sh:class`` on the property shape) and the
+    qualified-cardinality shape (``sh:qualifiedValueShape`` carrying ``sh:class``
+    or an ``sh:in`` list of alternatives).
+    """
+    q = """
+    PREFIX watr: <urn:nawi-water-ontology#>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT DISTINCT ?process WHERE {
+        ?equip_cls sh:property ?shape .
+        ?shape sh:path watr:hasProcess .
+        {
+            ?shape sh:class ?process .
+        } UNION {
+            ?shape sh:qualifiedValueShape/sh:class ?process .
+        } UNION {
+            ?shape sh:qualifiedValueShape/sh:in/rdf:rest*/rdf:first ?process .
+        }
+    }
+    """
+    if ('process_of_equip', equip_cls) not in CACHE:
+        CACHE[('process_of_equip', equip_cls)] = set(
+            row.process for row in g.query(q, initBindings={'equip_cls': equip_cls})
+        )
+    return CACHE[('process_of_equip', equip_cls)]
 
 
-def _collect_class_constraints(g: Graph) -> dict:
-    """Return {device_class: {path: set(required_classes)}}."""
-    constraints = defaultdict(lambda: defaultdict(set))
-    for shape, _, prop in g.triples((None, SH.property, None)):
-        path = g.value(prop, SH.path)
-        cls = g.value(prop, SH["class"])
-        if path is None or cls is None:
-            continue
-        constraints[shape][path].add(cls)
-    return constraints
+def _find_equipment_class_ancestor_set(cls: URIRef, g: Graph):
+    """Return the proper equipment superclasses of an equipment class."""
+    q = """
+    PREFIX watr: <urn:nawi-water-ontology#>
+    PREFIX s223: <http://data.ashrae.org/standard223#>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+    SELECT DISTINCT ?ancestor WHERE {
+        ?cls rdfs:subClassOf* ?ancestor .
+        ?ancestor rdfs:subClassOf* s223:Equipment .
+        FILTER (?ancestor != ?cls) .
+        FILTER (?ancestor != s223:Equipment) .
+    }
+    """
+    return set(row.ancestor for row in g.query(q, initBindings={'cls': cls}))
 
 
-def _collect_process_classes(g: Graph) -> set:
-    """Anything named watr:Process-* or used as sh:class on watr:hasProcess."""
-    candidates = set()
-    watr_str = str(WATR)
-    for s in set(g.subjects()):
-        s_str = str(s)
-        if s_str.startswith(watr_str) and s_str[len(watr_str):].startswith("Process-"):
-            candidates.add(s)
-    for _, _, prop in g.triples((None, SH.property, None)):
-        if g.value(prop, SH.path) == WATR.hasProcess:
-            cls = g.value(prop, SH["class"])
-            if cls is not None:
-                candidates.add(cls)
-    candidates.discard(PROCESS)
-    return candidates
+def _find_process_class_ancestor_set(cls: URIRef, g: Graph):
+    """Return the superclasses of a process class, including the class itself."""
+    q = """
+    PREFIX watr: <urn:nawi-water-ontology#>
+
+    SELECT DISTINCT ?ancestor WHERE {
+        ?cls rdfs:subClassOf* ?ancestor .
+        FILTER (?ancestor != ?cls)
+    }
+    """
+    ancestors = set(row.ancestor for row in g.query(q, initBindings={'cls': cls}))
+    ancestors.add(cls)  # a process trivially refines itself
+    return ancestors
 
 
 @pytest.fixture(scope="module")
@@ -87,59 +130,40 @@ def water_graph() -> Graph:
     return g
 
 
-def test_all_processes_are_subclass_of_process(water_graph: Graph) -> None:
+def test_equipment_process_constraints_are_consistent(water_graph: Graph) -> None:
+    g = water_graph
+    equipments = _find_equipments(g)
+    process_of_equip = {e: _find_process_of_equip(e, g) for e in equipments}
+    equipment_ancestors = {e: _find_equipment_class_ancestor_set(e, g) for e in equipments}
+
+    referenced = set().union(*process_of_equip.values()) if process_of_equip else set()
+    process_ancestors = {p: _find_process_class_ancestor_set(p, g) for p in referenced}
+
+    # (equip, ancestor, ancestor_process, equip_processes)
     violations = []
-    for cls in sorted(_collect_process_classes(water_graph), key=str):
-        if PROCESS not in _transitive_superclasses(water_graph, cls):
-            parents = list(water_graph.objects(cls, RDFS.subClassOf))
-            violations.append((cls, parents))
+    for equip, processes in process_of_equip.items():
+        if not processes:
+            continue
+        for ancestor in equipment_ancestors[equip]:
+            for ancestor_process in process_of_equip.get(ancestor, set()):
+                # At least one of the equipment's processes must be the same as,
+                # or a subclass of, the process the ancestor requires.
+                refines = any(
+                    ancestor_process in process_ancestors[p] for p in processes
+                )
+                if not refines:
+                    violations.append((equip, ancestor, ancestor_process, processes))
 
     if not violations:
         return
 
-    lines = [
-        f"{len(violations)} process class(es) are NOT rdfs:subClassOf* {_qname(water_graph, PROCESS)}:"
-    ]
-    for cls, parents in violations:
-        parents_str = (
-            ", ".join(_qname(water_graph, p) for p in parents)
-            if parents
-            else "(no rdfs:subClassOf declared)"
-        )
-        lines.append(f"- {_qname(water_graph, cls)}")
-        lines.append(f"    direct parents: {parents_str}")
-    pytest.fail("\n".join(lines))
-
-
-def test_subclass_shacl_constraints_are_consistent(water_graph: Graph) -> None:
-    constraints = _collect_class_constraints(water_graph)
-    violations = []
-
-    for device_cls, paths in constraints.items():
-        ancestors = _transitive_superclasses(water_graph, device_cls)
-        for path, required_classes in paths.items():
-            for ancestor in ancestors:
-                ancestor_required = constraints.get(ancestor, {}).get(path)
-                if not ancestor_required:
-                    continue
-                for child_cls in required_classes:
-                    for anc_cls in ancestor_required:
-                        if not _is_subclass_of(water_graph, child_cls, anc_cls):
-                            violations.append((device_cls, ancestor, path, child_cls, anc_cls))
-
-    if not violations:
-        return
-
-    lines = [f"{len(violations)} sh:class constraint inconsistency(ies):"]
-    for device, ancestor, path, child_cls, anc_cls in violations:
+    lines = [f"{len(violations)} watr:hasProcess refinement inconsistency(ies):"]
+    for equip, ancestor, ancestor_process, processes in violations:
+        procs_str = ", ".join(sorted(_qname(g, p) for p in processes))
+        lines.append(f"- {_qname(g, equip)} (subClassOf* {_qname(g, ancestor)})")
+        lines.append(f"    ancestor requires: {_qname(g, ancestor_process)}")
+        lines.append(f"    but equipment's processes are: {procs_str}")
         lines.append(
-            f"- {_qname(water_graph, device)} (subClassOf* {_qname(water_graph, ancestor)})"
-        )
-        lines.append(f"    path: {_qname(water_graph, path)}")
-        lines.append(f"    requires: {_qname(water_graph, child_cls)}")
-        lines.append(f"    but ancestor requires: {_qname(water_graph, anc_cls)}")
-        lines.append(
-            f"    -> {_qname(water_graph, child_cls)} is NOT rdfs:subClassOf* "
-            f"{_qname(water_graph, anc_cls)}"
+            f"    -> none of them is rdfs:subClassOf* {_qname(g, ancestor_process)}"
         )
     pytest.fail("\n".join(lines))

--- a/tests/test_processtype_consistency.py
+++ b/tests/test_processtype_consistency.py
@@ -29,8 +29,6 @@ ROOT = Path(__file__).resolve().parents[1]
 WATER_TTL = ROOT / "libraries" / "water.ttl"
 WATR = Namespace("urn:nawi-water-ontology#")
 
-# Reuse the consistency helpers from the standalone script unchanged.
-sys.path.insert(0, str(ROOT / "scripts"))
 
 CACHE = {}
 

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -155,7 +155,7 @@ watr:SequencingBatchReactor
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Fluid-Sludge ;
+                sh:class watr:Fluid-Sludge ;
             ] ;
         ] ;
     ] ;

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -26,7 +26,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:InletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -38,7 +38,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
             sh:not [
                 # this is NOT a drain connection point! Tanks with a drain connection point must have a separate outlet connection point for the drain.
@@ -58,7 +58,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
             sh:property [
                 sh:path s223:hasRole ;
@@ -74,7 +74,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
             sh:property [
                 sh:path s223:hasRole ;
@@ -97,7 +97,7 @@ watr:Reactor a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
             sh:property [
                 sh:path s223:hasRole ;
@@ -120,7 +120,7 @@ watr:SeparationTank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -155,7 +155,7 @@ watr:SequencingBatchReactor
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Fluid-Sludge ;
+                sh:class s223:Fluid-Sludge ;
             ] ;
         ] ;
     ] ;
@@ -169,7 +169,7 @@ watr:SequencingBatchReactor
                 sh:class s223:InletConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:hasValue s223:Mix-Fluid ;
+                    sh:class s223:Mix-Fluid ;
                 ] ;
             ] ;
         ] ;
@@ -181,7 +181,7 @@ watr:SequencingBatchReactor
                 sh:class s223:OutletConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:hasValue s223:Mix-Fluid ;
+                    sh:class s223:Mix-Fluid ;
                 ] ;
             ] ;
             
@@ -195,7 +195,7 @@ watr:SequencingBatchReactor
                 sh:class s223:BidirectionalConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:hasValue s223:Mix-Fluid ;
+                    sh:class s223:Mix-Fluid ;
                 ] ;
             ] ;
         ] ]
@@ -214,7 +214,7 @@ watr:PlugFlowReactor
             sh:class s223:InletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -226,7 +226,7 @@ watr:PlugFlowReactor
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -26,7 +26,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:InletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Mix-Fluid ;
+                sh:hasValue s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -38,7 +38,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Mix-Fluid ;
+                sh:hasValue s223:Mix-Fluid ;
             ] ;
             sh:not [
                 # this is NOT a drain connection point! Tanks with a drain connection point must have a separate outlet connection point for the drain.
@@ -74,7 +74,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Mix-Fluid ;
+                sh:hasValue s223:Mix-Fluid ;
             ] ;
             sh:property [
                 sh:path s223:hasRole ;
@@ -97,7 +97,7 @@ watr:Reactor a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Mix-Fluid ;
+                sh:hasValue s223:Mix-Fluid ;
             ] ;
             sh:property [
                 sh:path s223:hasRole ;
@@ -120,7 +120,7 @@ watr:SeparationTank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Mix-Fluid ;
+                sh:hasValue s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -155,7 +155,7 @@ watr:SequencingBatchReactor
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Fluid-Sludge ;
+                sh:hasValue s223:Fluid-Sludge ;
             ] ;
         ] ;
     ] ;
@@ -169,7 +169,7 @@ watr:SequencingBatchReactor
                 sh:class s223:InletConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:class s223:Mix-Fluid ;
+                    sh:hasValue s223:Mix-Fluid ;
                 ] ;
             ] ;
         ] ;
@@ -181,7 +181,7 @@ watr:SequencingBatchReactor
                 sh:class s223:OutletConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:class s223:Mix-Fluid ;
+                    sh:hasValue s223:Mix-Fluid ;
                 ] ;
             ] ;
             
@@ -195,7 +195,7 @@ watr:SequencingBatchReactor
                 sh:class s223:BidirectionalConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:class s223:Mix-Fluid ;
+                    sh:hasValue s223:Mix-Fluid ;
                 ] ;
             ] ;
         ] ]
@@ -214,7 +214,7 @@ watr:PlugFlowReactor
             sh:class s223:InletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Mix-Fluid ;
+                sh:hasValue s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -226,7 +226,7 @@ watr:PlugFlowReactor
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:class s223:Mix-Fluid ;
+                sh:hasValue s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -26,7 +26,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:InletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -38,7 +38,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
             sh:not [
                 # this is NOT a drain connection point! Tanks with a drain connection point must have a separate outlet connection point for the drain.
@@ -74,7 +74,7 @@ watr:Tank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
             sh:property [
                 sh:path s223:hasRole ;
@@ -120,7 +120,7 @@ watr:SeparationTank a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -155,7 +155,7 @@ watr:SequencingBatchReactor
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Fluid-Sludge ;
+                sh:class s223:Fluid-Sludge ;
             ] ;
         ] ;
     ] ;
@@ -169,7 +169,7 @@ watr:SequencingBatchReactor
                 sh:class s223:InletConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:hasValue s223:Mix-Fluid ;
+                    sh:class s223:Mix-Fluid ;
                 ] ;
             ] ;
         ] ;
@@ -181,7 +181,7 @@ watr:SequencingBatchReactor
                 sh:class s223:OutletConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:hasValue s223:Mix-Fluid ;
+                    sh:class s223:Mix-Fluid ;
                 ] ;
             ] ;
             
@@ -195,7 +195,7 @@ watr:SequencingBatchReactor
                 sh:class s223:BidirectionalConnectionPoint ;
                 sh:property [
                     sh:path s223:hasMedium ;
-                    sh:hasValue s223:Mix-Fluid ;
+                    sh:class s223:Mix-Fluid ;
                 ] ;
             ] ;
         ] ]
@@ -214,7 +214,7 @@ watr:PlugFlowReactor
             sh:class s223:InletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;
@@ -226,7 +226,7 @@ watr:PlugFlowReactor
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
         ] ;
     ] ;

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -1032,6 +1032,7 @@ watr:TotalOrganicCompoundConcentrationSensor
 watr:Valve 
     a s223:Class, sh:NodeShape; 
     a watr:Class ;
+    rdfs:comment "A device that regulates, directs or controls the flow of a fluid (gases or liquids) by opening, closing, or partially obstructing various passageways." ;
     rdfs:label "Valve" ;
     rdfs:subClassOf s223:Valve 
 .
@@ -1039,6 +1040,7 @@ watr:Valve
 watr:VariableFrequencyDrive
     a s223:Class, sh:NodeShape ;
     a watr:Class ;
+    rdfs:comment "A type of AC motor drive that controls speed and torque by varying the frequency of the input electricity." ;
     rdfs:subClassOf s223:VariableFrequencyDrive ;
     rdfs:label "Variable Frequency Drive" 
 .
@@ -1046,6 +1048,7 @@ watr:VariableFrequencyDrive
 watr:ThreeWayValve 
     a s223:Class, sh:NodeShape; 
     a watr:Class ;
+    rdfs:comment "A valve that features three ports (connections)" ;
     rdfs:label "Three Way Valve" ;
     rdfs:subClassOf s223:Valve 
 .
@@ -1053,6 +1056,7 @@ watr:ThreeWayValve
 watr:CheckValve
     a s223:Class, sh:NodeShape; 
     a watr:Class ;
+    rdfs:comment "A valve that normally allows fluid (liquid or gas) to flow through it in only one direction" ;
     rdfs:label "Check Valve" ;
     rdfs:subClassOf s223:Valve
 .
@@ -1060,6 +1064,7 @@ watr:CheckValve
 watr:BallValve
     a s223:Class, sh:NodeShape; 
     a watr:Class ;
+    rdfs:comment "A valve which operates using a spherical ball with a hole (also known as a bore) through the middle." ;
     rdfs:label "Ball Valve" ;
     rdfs:subClassOf s223:Valve
 .
@@ -1067,6 +1072,7 @@ watr:BallValve
 watr:ButterflyValve
     a s223:Class, sh:NodeShape; 
     a watr:Class ;
+    rdfs:comment "A quarter-turn rotary valve used to isolate, start, stop, or regulate the flow of fluids" ;
     rdfs:label "Butterfly Valve" ;
     rdfs:subClassOf s223:Valve
 .
@@ -1074,6 +1080,7 @@ watr:ButterflyValve
 watr:GlobeValve
     a s223:Class, sh:NodeShape; 
     a watr:Class ;
+    rdfs:comment "A linear-motion valve primarily used for stopping, starting, and regulating (throttling) fluid flow" ;
     rdfs:label "Globe Valve" ;
     rdfs:subClassOf s223:Valve
 .
@@ -1081,6 +1088,7 @@ watr:GlobeValve
 watr:PlugValve
     a s223:Class, sh:NodeShape; 
     a watr:Class ;
+    rdfs:comment "A valve with cylindrical or conically tapered plugs which can be rotated inside the valve body to control flow through the valve" ;
     rdfs:label "Plug Valve" ;
     rdfs:subClassOf s223:Valve
 .
@@ -1096,6 +1104,7 @@ watr:AirReleaseValve
 watr:Controller 
     a s223:Class, sh:NodeShape ;
     a watr:Class ;
+    rdfs:comment "A piece of equipment for regulation of a system or component in normal operation, which executes one or more `Function`s." ;
     rdfs:label "Controller" ;
     rdfs:subClassOf s223:Controller .
 

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -126,9 +126,10 @@ watr:SeparationTank a sh:NodeShape ;
     ] ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Separation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Separation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of SeparationTank must have the Separation process." ;
     ] ;
 .
@@ -141,9 +142,10 @@ watr:SequencingBatchReactor
     rdfs:subClassOf watr:Reactor, watr:SeparationTank ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-ActivatedSludge ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-ActivatedSludge ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of SequencingBatchReactor must have the ActivatedSludge process." ;
     ] ;
     # has 1 in, 1out (both water),  OR 1 bidirectional (water)
@@ -247,9 +249,10 @@ watr:StaticMixer
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Mixing ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Mixing ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of StaticMixer must have the Mixing process." ;
     ] .
 
@@ -261,9 +264,10 @@ watr:AerationBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Aeration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Aeration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of AerationBasin must have the Aeration process." ;
     ] ;
     sh:property [
@@ -281,9 +285,10 @@ watr:MixingBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Mixing ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Mixing ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of MixingBasin must have the Mixing process." ;
     ] ;
     sh:property [
@@ -301,9 +306,10 @@ watr:MembraneAeratedBiofilmReaactor
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Aeration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Aeration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of MembraneAeratedBiofilmReaactor must have the Aeration process." ;
     ] .
     
@@ -315,9 +321,10 @@ watr:CoagulationBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Coagulation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Coagulation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of CoagulationBasin must have the Coagulation process." ;
     ] .
 
@@ -329,9 +336,10 @@ watr:FlocculationBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Flocculation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Flocculation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of FlocculationBasin must have the Flocculation process." ;
     ] .
 
@@ -343,9 +351,10 @@ watr:Digester
     rdfs:subClassOf watr:Reactor, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Digestion ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Digestion ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Digester must have the Digestion process." ;
     ] .
 
@@ -357,9 +366,10 @@ watr:AnaerobicDigester
     rdfs:subClassOf watr:Digester ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-AnaerobicDigestion ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-AnaerobicDigestion ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of AnaerobicDigester must have the AnaerobicDigestion process." ;
     ] .
 
@@ -371,9 +381,10 @@ watr:AerobicDigester
     rdfs:subClassOf watr:Digester ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-AerobicDigestion ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-AerobicDigestion ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of AerobicDigester must have the AerobicDigestion process." ;
     ] .
 
@@ -385,9 +396,10 @@ watr:DisinfectionUnit
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Disinfection ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Disinfection ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of DisinfectionUnit must have the Disinfection process." ;
     ] .
 
@@ -399,9 +411,10 @@ watr:ChlorinationUnit
     rdfs:subClassOf watr:DisinfectionUnit ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Chlorination ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Chlorination ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of ChlorinationUnit must have the Chlorination process." ;
     ] .
 
@@ -413,9 +426,10 @@ watr:UltravioletLightUnit
     rdfs:subClassOf watr:DisinfectionUnit ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-UVDisinfection ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-UVDisinfection ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of UltravioletLightUnit must have the UVDisinfection process." ;
     ] .
 
@@ -427,9 +441,10 @@ watr:SedimentationTank
     rdfs:subClassOf watr:SeparationTank ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Sedimentation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Sedimentation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of SedimentationTank must have the Sedimentation process." ;
     ] .
 
@@ -441,9 +456,10 @@ watr:ImhoffTank
     rdfs:subClassOf watr:SedimentationTank ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Sedimentation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Sedimentation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of ImhoffTank must have the Sedimentation process." ;
     ] .
 
@@ -455,9 +471,10 @@ watr:Screen
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Screening ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Screening ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Screen must have the Screening process." ;
     ] .
 
@@ -469,9 +486,10 @@ watr:GritChamber
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Sedimentation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Sedimentation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of GritChamber must have the Sedimentation process." ;
     ] .
 
@@ -511,9 +529,10 @@ watr:Cogenerator
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Cogeneration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Cogeneration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Cogenerator must have the Cogeneration process." ;
     ] .
 
@@ -525,9 +544,10 @@ watr:Boiler
     rdfs:subClassOf s223:Boiler, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Incineration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Incineration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Boiler must have the Incineration process." ;
     ] .
 
@@ -567,9 +587,10 @@ watr:DewateringUnit
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Dewatering ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Dewatering ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of DewateringUnit must have the Dewatering process." ;
     ] .
 
@@ -588,9 +609,10 @@ watr:DissolvedAirFlotationThickener
     rdfs:subClassOf watr:Thickener;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Flotation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Flotation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of DissolvedAirFlotationThickener must have the Flotation process." ;
     ] .
 
@@ -602,9 +624,10 @@ watr:CentrifugalThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Centrifugation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Centrifugation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of CentrifugalThickener must have the Centrifugation process." ;
     ] .
 
@@ -616,9 +639,10 @@ watr:GravityThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Sedimentation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Sedimentation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of GravityThickener must have the Sedimentation process." ;
     ] .
 
@@ -630,9 +654,10 @@ watr:BeltThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Filtration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Filtration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of BeltThickener must have the Filtration process." ;
     ] .
 
@@ -651,9 +676,10 @@ watr:RotaryDrumThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Filtration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Filtration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of RotaryDrumThickener must have the Filtration process." ;
     ] .
 
@@ -665,9 +691,10 @@ watr:Filter
     rdfs:subClassOf s223:Filter, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Filtration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Filtration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Filter must have the Filtration process." ;
     ] .
 
@@ -679,9 +706,10 @@ watr:ReverseOsmosisMembrane
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-ReverseOsmosis ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-ReverseOsmosis ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of ReverseOsmosisMembrane must have the ReverseOsmosis process." ;
     ] .
 
@@ -693,9 +721,10 @@ watr:RotatingBiologicalContactor
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Biofiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Biofiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of RotatingBiologicalContactor must have the Biofiltration process." ;
     ] .
 
@@ -707,9 +736,10 @@ watr:TricklingFilter
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-TricklingFiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-TricklingFiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of TricklingFilter must have the TricklingFiltration process." ;
     ] .
 
@@ -721,9 +751,10 @@ watr:OxidationDitch
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-ActivatedSludge ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-ActivatedSludge ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of OxidationDitch must have the ActivatedSludge process." ;
     ] .
 
@@ -735,16 +766,18 @@ watr:MembraneBioreactor
     rdfs:subClassOf watr:Filter, watr:Reactor, watr:SeparationTank ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:in ( watr:Process-Microfiltration watr:Process-Ultrafiltration ) ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:in ( watr:Process-Microfiltration watr:Process-Ultrafiltration ) ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of MembraneBioreactor must have either the Microfiltration or Ultrafiltration process." ;
     ] ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Biofiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Biofiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of MembraneBioreactor must have the Biofiltration process." ;
     ] .
 
@@ -756,9 +789,10 @@ watr:MicrofiltrationUnit
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Microfiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Microfiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of MicrofiltrationUnit must have the Microfiltration process." ;
     ] .
 
@@ -770,9 +804,10 @@ watr:UltrafiltrationUnit
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Ultrafiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Ultrafiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of UltrafiltrationUnit must have the Ultrafiltration process." ;
     ] .
 
@@ -791,9 +826,10 @@ watr:MediaFiltration
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-MediaFiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-MediaFiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of MediaFiltration must have the MediaFiltration process." ;
     ] .
 
@@ -805,9 +841,10 @@ watr:RapidSandFilter
     rdfs:subClassOf watr:MediaFiltration ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-RapidSandFiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-RapidSandFiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of RapidSandFilter must have the RapidSandFiltration process." ;
     ] .
 
@@ -826,9 +863,10 @@ watr:IonExchangeMembrane
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-IonExchange ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-IonExchange ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of IonExchangeMembrane must have the IonExchange process." ;
     ] .
 
@@ -840,9 +878,10 @@ watr:ElectrodialysisUnit
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Electrodialysis ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Electrodialysis ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of ElectrodialysisUnit must have the Electrodialysis process." ;
     ] .
 
@@ -854,9 +893,10 @@ watr:Electrolyzer
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Electrolysis ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Electrolysis ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Electrolyzer must have the Electrolysis process." ;
     ] .
 
@@ -868,9 +908,10 @@ watr:Crystallizer
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Crystallization ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Crystallization ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Crystallizer must have the Crystallization process." ;
     ] .
 
@@ -889,9 +930,10 @@ watr:Evaporator
     rdfs:subClassOf s223:HeatExchanger, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Evaporation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Evaporation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Evaporator must have the Evaporation process." ;
     ] .
 
@@ -903,9 +945,10 @@ watr:Condenser
     rdfs:subClassOf s223:HeatExchanger, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Condensation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Condensation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Condenser must have the Condensation process." ;
     ] .
 
@@ -1141,19 +1184,21 @@ watr:ElectroDialyticCrystallizer
     a watr:Class ;
     rdfs:label "Electro-Dialytic Crystallizer (EDC)" ;
     rdfs:comment "A modular system designed for brine concentration and crystallization, integrating electrodialysis and crystallization." ;
-    rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
+    rdfs:subClassOf s223:Equipment, watr:UnitProcess  ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Electrodialysis ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Electrodialysis ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of ElectroDialyticCrystallizer must have the Electrodialysis process." ;
     ] ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Crystallization ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Crystallization ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of ElectroDialyticCrystallizer must have the Crystallization process." ;
     ] .
 
@@ -1193,9 +1238,10 @@ watr:SolventExtractionSystem
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-SolventExtraction ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-SolventExtraction ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of SolventExtractionSystem must have the SolventExtraction process." ;
     ] .
 
@@ -1221,9 +1267,10 @@ watr:UVH2O2Reactor
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-AdvancedOxidation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-AdvancedOxidation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of UVH2O2Reactor must have the AdvancedOxidation process." ;
     ] .
 
@@ -1235,9 +1282,10 @@ watr:BiologicalAeratedFilter
     rdfs:subClassOf watr:Reactor, watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-BiologicallyActiveFiltration ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-BiologicallyActiveFiltration ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of BiologicalAeratedFilter must have the BiologicallyActiveFiltration process." ;
     ] .
 
@@ -1249,9 +1297,10 @@ watr:ElectrocoagulationUnit
     rdfs:subClassOf s223:Equipment, watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Electrocoagulation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Electrocoagulation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of ElectrocoagulationUnit must have the Electrocoagulation process." ;
     ] .
 
@@ -1263,9 +1312,10 @@ watr:OzonationUnit
     rdfs:subClassOf s223:Equipment, watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Ozonation ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Ozonation ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of OzonationUnit must have the Ozonation process." ;
     ] .
 
@@ -1277,9 +1327,10 @@ watr:GranularActivatedCarbonAdsorber
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-GranularActivatedCarbon ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-GranularActivatedCarbon ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of GranulatedActivatedCarbonAdsorber must have the GranularActivatedCarbon process." ;
     ] .
 
@@ -1291,9 +1342,10 @@ watr:Grinder
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:class watr:Process-Comminution ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
+        sh:qualifiedValueShape [ sh:class watr:Process-Comminution ];
+        sh:qualifiedValueShapesDisjoint true ;
+        sh:qualifiedMinCount 1 ;
+		sh:qualifiedMaxCount 1 ;
         sh:message "Instances of Grinder must have the Comminution process." ;
     ] 
 .

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -97,7 +97,7 @@ watr:Reactor a sh:NodeShape ;
             sh:class s223:OutletConnectionPoint ;
             sh:property [
                 sh:path s223:hasMedium ;
-                sh:hasValue s223:Mix-Fluid ;
+                sh:class s223:Mix-Fluid ;
             ] ;
             sh:property [
                 sh:path s223:hasRole ;

--- a/water/equipment.ttl
+++ b/water/equipment.ttl
@@ -126,7 +126,7 @@ watr:SeparationTank a sh:NodeShape ;
     ] ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Separation ;
+        sh:class watr:Process-Separation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of SeparationTank must have the Separation process." ;
@@ -141,7 +141,7 @@ watr:SequencingBatchReactor
     rdfs:subClassOf watr:Reactor, watr:SeparationTank ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-ActivatedSludge ;
+        sh:class watr:Process-ActivatedSludge ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of SequencingBatchReactor must have the ActivatedSludge process." ;
@@ -247,7 +247,7 @@ watr:StaticMixer
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Mixing ;
+        sh:class watr:Process-Mixing ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of StaticMixer must have the Mixing process." ;
@@ -261,7 +261,7 @@ watr:AerationBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Aeration ;
+        sh:class watr:Process-Aeration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of AerationBasin must have the Aeration process." ;
@@ -281,7 +281,7 @@ watr:MixingBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Mixing ;
+        sh:class watr:Process-Mixing ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of MixingBasin must have the Mixing process." ;
@@ -301,7 +301,7 @@ watr:MembraneAeratedBiofilmReaactor
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Aeration ;
+        sh:class watr:Process-Aeration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of MembraneAeratedBiofilmReaactor must have the Aeration process." ;
@@ -315,7 +315,7 @@ watr:CoagulationBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Coagulation ;
+        sh:class watr:Process-Coagulation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of CoagulationBasin must have the Coagulation process." ;
@@ -329,7 +329,7 @@ watr:FlocculationBasin
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Flocculation ;
+        sh:class watr:Process-Flocculation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of FlocculationBasin must have the Flocculation process." ;
@@ -343,7 +343,7 @@ watr:Digester
     rdfs:subClassOf watr:Reactor, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Digestion ;
+        sh:class watr:Process-Digestion ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Digester must have the Digestion process." ;
@@ -357,7 +357,7 @@ watr:AnaerobicDigester
     rdfs:subClassOf watr:Digester ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-AnaerobicDigestion ;
+        sh:class watr:Process-AnaerobicDigestion ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of AnaerobicDigester must have the AnaerobicDigestion process." ;
@@ -371,7 +371,7 @@ watr:AerobicDigester
     rdfs:subClassOf watr:Digester ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-AerobicDigestion ;
+        sh:class watr:Process-AerobicDigestion ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of AerobicDigester must have the AerobicDigestion process." ;
@@ -385,7 +385,7 @@ watr:DisinfectionUnit
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Disinfection ;
+        sh:class watr:Process-Disinfection ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of DisinfectionUnit must have the Disinfection process." ;
@@ -399,7 +399,7 @@ watr:ChlorinationUnit
     rdfs:subClassOf watr:DisinfectionUnit ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Chlorination ;
+        sh:class watr:Process-Chlorination ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of ChlorinationUnit must have the Chlorination process." ;
@@ -413,7 +413,7 @@ watr:UltravioletLightUnit
     rdfs:subClassOf watr:DisinfectionUnit ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-UVDisinfection ;
+        sh:class watr:Process-UVDisinfection ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of UltravioletLightUnit must have the UVDisinfection process." ;
@@ -427,7 +427,7 @@ watr:SedimentationTank
     rdfs:subClassOf watr:SeparationTank ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Sedimentation ;
+        sh:class watr:Process-Sedimentation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of SedimentationTank must have the Sedimentation process." ;
@@ -441,7 +441,7 @@ watr:ImhoffTank
     rdfs:subClassOf watr:SedimentationTank ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Sedimentation ;
+        sh:class watr:Process-Sedimentation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of ImhoffTank must have the Sedimentation process." ;
@@ -455,7 +455,7 @@ watr:Screen
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Screening ;
+        sh:class watr:Process-Screening ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Screen must have the Screening process." ;
@@ -469,7 +469,7 @@ watr:GritChamber
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Sedimentation ;
+        sh:class watr:Process-Sedimentation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of GritChamber must have the Sedimentation process." ;
@@ -511,7 +511,7 @@ watr:Cogenerator
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Cogeneration ;
+        sh:class watr:Process-Cogeneration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Cogenerator must have the Cogeneration process." ;
@@ -525,7 +525,7 @@ watr:Boiler
     rdfs:subClassOf s223:Boiler, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Incineration ;
+        sh:class watr:Process-Incineration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Boiler must have the Incineration process." ;
@@ -567,7 +567,7 @@ watr:DewateringUnit
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Dewatering ;
+        sh:class watr:Process-Dewatering ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of DewateringUnit must have the Dewatering process." ;
@@ -588,7 +588,7 @@ watr:DissolvedAirFlotationThickener
     rdfs:subClassOf watr:Thickener;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Flotation ;
+        sh:class watr:Process-Flotation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of DissolvedAirFlotationThickener must have the Flotation process." ;
@@ -602,7 +602,7 @@ watr:CentrifugalThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Centrifugation ;
+        sh:class watr:Process-Centrifugation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of CentrifugalThickener must have the Centrifugation process." ;
@@ -616,7 +616,7 @@ watr:GravityThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Sedimentation ;
+        sh:class watr:Process-Sedimentation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of GravityThickener must have the Sedimentation process." ;
@@ -630,7 +630,7 @@ watr:BeltThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Filtration ;
+        sh:class watr:Process-Filtration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of BeltThickener must have the Filtration process." ;
@@ -651,7 +651,7 @@ watr:RotaryDrumThickener
     rdfs:subClassOf watr:Thickener ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Filtration ;
+        sh:class watr:Process-Filtration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of RotaryDrumThickener must have the Filtration process." ;
@@ -665,7 +665,7 @@ watr:Filter
     rdfs:subClassOf s223:Filter, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Filtration ;
+        sh:class watr:Process-Filtration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Filter must have the Filtration process." ;
@@ -679,7 +679,7 @@ watr:ReverseOsmosisMembrane
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-ReverseOsmosis ;
+        sh:class watr:Process-ReverseOsmosis ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of ReverseOsmosisMembrane must have the ReverseOsmosis process." ;
@@ -693,7 +693,7 @@ watr:RotatingBiologicalContactor
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Biofiltration ;
+        sh:class watr:Process-Biofiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of RotatingBiologicalContactor must have the Biofiltration process." ;
@@ -707,7 +707,7 @@ watr:TricklingFilter
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-TricklingFiltration ;
+        sh:class watr:Process-TricklingFiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of TricklingFilter must have the TricklingFiltration process." ;
@@ -721,7 +721,7 @@ watr:OxidationDitch
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-ActivatedSludge ;
+        sh:class watr:Process-ActivatedSludge ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of OxidationDitch must have the ActivatedSludge process." ;
@@ -742,7 +742,7 @@ watr:MembraneBioreactor
     ] ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Biofiltration ;
+        sh:class watr:Process-Biofiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of MembraneBioreactor must have the Biofiltration process." ;
@@ -756,7 +756,7 @@ watr:MicrofiltrationUnit
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Microfiltration ;
+        sh:class watr:Process-Microfiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of MicrofiltrationUnit must have the Microfiltration process." ;
@@ -770,7 +770,7 @@ watr:UltrafiltrationUnit
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Ultrafiltration ;
+        sh:class watr:Process-Ultrafiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of UltrafiltrationUnit must have the Ultrafiltration process." ;
@@ -791,7 +791,7 @@ watr:MediaFiltration
     rdfs:subClassOf watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-MediaFiltration ;
+        sh:class watr:Process-MediaFiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of MediaFiltration must have the MediaFiltration process." ;
@@ -805,7 +805,7 @@ watr:RapidSandFilter
     rdfs:subClassOf watr:MediaFiltration ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-RapidSandFiltration ;
+        sh:class watr:Process-RapidSandFiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of RapidSandFilter must have the RapidSandFiltration process." ;
@@ -826,7 +826,7 @@ watr:IonExchangeMembrane
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-IonExchange ;
+        sh:class watr:Process-IonExchange ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of IonExchangeMembrane must have the IonExchange process." ;
@@ -840,7 +840,7 @@ watr:ElectrodialysisUnit
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Electrodialysis ;
+        sh:class watr:Process-Electrodialysis ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of ElectrodialysisUnit must have the Electrodialysis process." ;
@@ -854,7 +854,7 @@ watr:Electrolyzer
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Electrolysis ;
+        sh:class watr:Process-Electrolysis ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Electrolyzer must have the Electrolysis process." ;
@@ -868,7 +868,7 @@ watr:Crystallizer
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Crystallization ;
+        sh:class watr:Process-Crystallization ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Crystallizer must have the Crystallization process." ;
@@ -889,7 +889,7 @@ watr:Evaporator
     rdfs:subClassOf s223:HeatExchanger, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Evaporation ;
+        sh:class watr:Process-Evaporation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Evaporator must have the Evaporation process." ;
@@ -903,7 +903,7 @@ watr:Condenser
     rdfs:subClassOf s223:HeatExchanger, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Condensation ;
+        sh:class watr:Process-Condensation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Condenser must have the Condensation process." ;
@@ -1135,14 +1135,14 @@ watr:ElectroDialyticCrystallizer
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Electrodialysis ;
+        sh:class watr:Process-Electrodialysis ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of ElectroDialyticCrystallizer must have the Electrodialysis process." ;
     ] ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Crystallization ;
+        sh:class watr:Process-Crystallization ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of ElectroDialyticCrystallizer must have the Crystallization process." ;
@@ -1184,7 +1184,7 @@ watr:SolventExtractionSystem
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-SolventExtraction ;
+        sh:class watr:Process-SolventExtraction ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of SolventExtractionSystem must have the SolventExtraction process." ;
@@ -1212,7 +1212,7 @@ watr:UVH2O2Reactor
     rdfs:subClassOf watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-AdvancedOxidation ;
+        sh:class watr:Process-AdvancedOxidation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of UVH2O2Reactor must have the AdvancedOxidation process." ;
@@ -1226,7 +1226,7 @@ watr:BiologicalAeratedFilter
     rdfs:subClassOf watr:Reactor, watr:Filter ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-BiologicallyActiveFiltration ;
+        sh:class watr:Process-BiologicallyActiveFiltration ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of BiologicalAeratedFilter must have the BiologicallyActiveFiltration process." ;
@@ -1240,7 +1240,7 @@ watr:ElectrocoagulationUnit
     rdfs:subClassOf s223:Equipment, watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Electrocoagulation ;
+        sh:class watr:Process-Electrocoagulation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of ElectrocoagulationUnit must have the Electrocoagulation process." ;
@@ -1254,7 +1254,7 @@ watr:OzonationUnit
     rdfs:subClassOf s223:Equipment, watr:Reactor ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Ozonation ;
+        sh:class watr:Process-Ozonation ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of OzonationUnit must have the Ozonation process." ;
@@ -1268,7 +1268,7 @@ watr:GranularActivatedCarbonAdsorber
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-GranularActivatedCarbon ;
+        sh:class watr:Process-GranularActivatedCarbon ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of GranulatedActivatedCarbonAdsorber must have the GranularActivatedCarbon process." ;
@@ -1282,7 +1282,7 @@ watr:Grinder
     rdfs:subClassOf s223:Equipment, watr:UnitProcess ;
     sh:property [
         sh:path watr:hasProcess ;
-        sh:hasValue watr:Process-Comminution ;
+        sh:class watr:Process-Comminution ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Instances of Grinder must have the Comminution process." ;

--- a/water/ontology.ttl
+++ b/water/ontology.ttl
@@ -15,6 +15,7 @@
   owl:imports <urn:nawi-water-ontology/equip> ;
   owl:imports <urn:nawi-water-ontology/processtypes> ;
   owl:imports <urn:nawi-water-ontology/substances> ;
+  owl:imports <urn:nawi-water-ontology/enumerationkinds> ;
   owl:imports sh: ;
 .
 

--- a/water/ontology.ttl
+++ b/water/ontology.ttl
@@ -10,8 +10,7 @@
 <urn:nawi-water-ontology>
   a owl:Ontology ;
   owl:imports <http://data.ashrae.org/standard223/1.0/model/all> ;
-  owl:imports <http://qudt.org/3.1.1/vocab/unit> ;
-  owl:imports <http://qudt.org/3.1.1/vocab/quantitykind> ;
+  owl:imports <http://qudt.org/3.2.1/shacl/qudt-all> ;
   owl:imports <urn:nawi-water-ontology/equip> ;
   owl:imports <urn:nawi-water-ontology/processtypes> ;
   owl:imports <urn:nawi-water-ontology/substances> ;

--- a/water/ontology.ttl
+++ b/water/ontology.ttl
@@ -10,8 +10,8 @@
 <urn:nawi-water-ontology>
   a owl:Ontology ;
   owl:imports <http://data.ashrae.org/standard223/1.0/model/all> ;
-  owl:imports <http://qudt.org/3.1.1/vocab/unit> ;
-  owl:imports <http://qudt.org/3.1.1/vocab/quantitykind> ;
+  owl:imports <http://qudt.org/3.2.1/vocab/unit> ;
+  owl:imports <http://qudt.org/3.2.1/vocab/quantitykind> ;
   owl:imports <urn:nawi-water-ontology/equip> ;
   owl:imports <urn:nawi-water-ontology/processtypes> ;
   owl:imports <urn:nawi-water-ontology/substances> ;

--- a/water/ontology.ttl
+++ b/water/ontology.ttl
@@ -10,8 +10,8 @@
 <urn:nawi-water-ontology>
   a owl:Ontology ;
   owl:imports <http://data.ashrae.org/standard223/1.0/model/all> ;
-  owl:imports <http://qudt.org/3.2.1/vocab/unit> ;
-  owl:imports <http://qudt.org/3.2.1/vocab/quantitykind> ;
+  owl:imports <http://qudt.org/3.3.0/vocab/unit> ;
+  owl:imports <http://qudt.org/3.3.0/vocab/quantitykind> ;
   owl:imports <urn:nawi-water-ontology/equip> ;
   owl:imports <urn:nawi-water-ontology/processtypes> ;
   owl:imports <urn:nawi-water-ontology/substances> ;

--- a/water/processtypes.ttl
+++ b/water/processtypes.ttl
@@ -157,6 +157,7 @@ watr:Process-MembraneProcess a watr:Class, watr:Process-MembraneProcess ;
 watr:Process-ReverseOsmosis a watr:Class, watr:Process-ReverseOsmosis ;
     rdfs:label "Reverse Osmosis (RO)" ;
     skos:definition "A core membrane separation process for desalination and advanced purification." ;
+    rdfs:subClassOf watr:Process-Filtration ;
     rdfs:subClassOf watr:Process-MembraneProcess .
 
 watr:Process-ClosedCircuitReverseOsmosis a watr:Class, watr:Process-ClosedCircuitReverseOsmosis ;
@@ -192,12 +193,12 @@ watr:Process-ElectroDialyticCrystallization a watr:Class, watr:Process-ElectroDi
 watr:Process-Comminution a watr:Class, watr:Process-Comminution ;
     rdfs:label "Comminution" ;
     skos:definition "Process of reducing solid materials into smaller particles through mechanical forces such as crushing, grinding, impact, shear, or compression." ;
-    rdfs:subClassOf watr:Process-Physical .
+    rdfs:subClassOf watr:Process-PhysicalProcess .
 
 watr:Process-BiosolidsDisposal a watr:Class, watr:Process-BiosolidsDisposal ;
     rdfs:label "BiosolidsDisposal" ;
     skos:definition "Generic process for unspecified disposal of biosolids (e.g., incineration, land application, landfilling, etc.)." ;
-    rdfs:subClassOf watr:Process-Physical .
+    rdfs:subClassOf watr:Process-PhysicalProcess .
 
 watr:Process-LandApplication a watr:Class, watr:Process-LandApplication ;
     rdfs:label "Land Application" ;
@@ -376,6 +377,7 @@ watr:Process-FourStageBardenpho a watr:Class, watr:Process-FourStageBardenpho ;
 watr:Process-ActivatedSludge a watr:Class, watr:Process-ActivatedSludge ;
     rdfs:label "Activated Sludge" ;
     skos:definition "Aerobic suspended-growth biological treatment" ;
+    rdfs:subClassOf watr:Process-Separation ;
     rdfs:subClassOf watr:Process-BiologicalProcess .
 
 
@@ -436,9 +438,9 @@ watr:Process-Digestion a watr:Class, watr:Process-Digestion ;
 watr:Process-AnaerobicDigestion a watr:Class, watr:Process-AnaerobicDigestion ;
     rdfs:label "Anaerobic Digestion" ;
     skos:definition "A biological process that breaks down organic matter in the absence of oxygen." ;
-    rdfs:subClassOf watr:Digestion .
+    rdfs:subClassOf watr:Process-Digestion .
 
 watr:Process-AerobicDigestion a watr:Class, watr:Process-AerobicDigestion ;
     rdfs:label "Aerobic Digestion" ;
     skos:definition "A biological process that breaks down organic matter in the presence of oxygen." ;
-    rdfs:subClassOf watr:Digestion .
+    rdfs:subClassOf watr:Process-Digestion .

--- a/water/processtypes.ttl
+++ b/water/processtypes.ttl
@@ -15,7 +15,7 @@
     rdfs:label "NAWI Water Process Types Ontology" ;
     rdfs:comment "An ontology for types of unit process" .
 
-watr:ProcessType a watr:Class, sh:NodeShape ;
+watr:Process a watr:Class, sh:NodeShape ;
     rdfs:label "Water Process" ;
     skos:definition "A process applied to water treatment." ;
     sh:property [
@@ -157,12 +157,11 @@ watr:Process-GranularActivatedCarbon a watr:Class, watr:Process-GranularActivate
 watr:Process-MembraneProcess a watr:Class, watr:Process-MembraneProcess ;
     rdfs:label "Membrane Process" ;
     skos:definition "A process that uses a semi-permeable membrane to separate substances." ;
-    rdfs:subClassOf watr:Process-PhysicalProcess .
+    rdfs:subClassOf watr:Process-Filtration .
 
 watr:Process-ReverseOsmosis a watr:Class, watr:Process-ReverseOsmosis ;
     rdfs:label "Reverse Osmosis (RO)" ;
     skos:definition "A core membrane separation process for desalination and advanced purification." ;
-    rdfs:subClassOf watr:Process-Filtration ;
     rdfs:subClassOf watr:Process-MembraneProcess .
 
 watr:Process-ClosedCircuitReverseOsmosis a watr:Class, watr:Process-ClosedCircuitReverseOsmosis ;

--- a/water/substances.ttl
+++ b/water/substances.ttl
@@ -342,7 +342,7 @@ watr:Constituent-Cyanide
     a sh:NodeShape ;
     rdfs:comment "Cyanide: A highly toxic chemical compound that can be harmful to aquatic life" ;
     rdfs:label "Constituent Cyanide" ;
-    rdfs:subClassOf watr:Medium-Constituent ;
+    rdfs:subClassOf s223:Medium-Constituent ;
 .
 watr:Constituent-Bacteria
     a watr:Class ;
@@ -350,7 +350,7 @@ watr:Constituent-Bacteria
     a sh:NodeShape ;
     rdfs:comment "Bacteria: Microscopic single-celled organisms that can be found in water" ;
     rdfs:label "Constituent Bacteria" ;
-    rdfs:subClassOf watr:Medium-Constituent ;
+    rdfs:subClassOf s223:Medium-Constituent ;
 .
 watr:Sludge-MixedLiquor
     a watr:Class ;

--- a/water/substances.ttl
+++ b/water/substances.ttl
@@ -358,7 +358,7 @@ watr:Sludge-MixedLiquor
     a sh:NodeShape ;
     rdfs:comment "Mixed liquor is the mixture of wastewater and activated sludge in the aeration basin of a wastewater treatment plant. It contains suspended solids and water." ;
     rdfs:label "Sludge-MixedLiquor" ;
-    rdfs:subClassOf s223:Fluid-Sludge ;
+    rdfs:subClassOf watr:Fluid-Sludge ;
     s223:composedOf [
         a s223:QuantifiableProperty ;
         s223:ofConstituent watr:Constituent-SuspendedSolids ;


### PR DESCRIPTION
 - Relax s223:hasMedium constraints on equipment connection points from sh:hasValue s223:Mix-Fluid (exact match) to sh:class s223:Mix-Fluid (accepts subclasses), so equipment shapes validate against more specific medium types like Fluid-Sludge. 
  - ~Remove sh:maxCount 1 from watr:hasProcess property shapes across equipment classes (Tanks, Reactors, Filters, Thickeners, Disinfection units, etc.), so a single piece of equipment can carry multiple process assignments while still being required to have the named process (sh:minCount 1 retained).~
        - This was an issue because there are conflicting process class requirements between subclasses and superclasses
        - *Instead of removing this rule I decide to check all the subclass relationships between processes and equipment so this can validate without conflict*
  - Fix two rdfs:subClassOf typos in substances.ttl: Constituent-Cyanide and Constituent-Bacteria now correctly subclass s223:Medium-Constituent instead of the non-existent  watr:Medium-Constituent.