### PR TITLE
Bump QUDT versions and add missing import

### DIFF
--- a/water/ontology.ttl
+++ b/water/ontology.ttl
@@ -15,6 +15,7 @@
   owl:imports <urn:nawi-water-ontology/equip> ;
   owl:imports <urn:nawi-water-ontology/processtypes> ;
   owl:imports <urn:nawi-water-ontology/substances> ;
+  owl:imports <urn:nawi-water-ontology/enumerationkinds> ;
   owl:imports sh: ;
 .
 

--- a/water/ontology.ttl
+++ b/water/ontology.ttl
@@ -10,8 +10,8 @@
 <urn:nawi-water-ontology>
   a owl:Ontology ;
   owl:imports <http://data.ashrae.org/standard223/1.0/model/all> ;
-  owl:imports <http://qudt.org/3.1.1/vocab/unit> ;
-  owl:imports <http://qudt.org/3.1.1/vocab/quantitykind> ;
+  owl:imports <http://qudt.org/3.2.1/vocab/unit> ;
+  owl:imports <http://qudt.org/3.2.1/vocab/quantitykind> ;
   owl:imports <urn:nawi-water-ontology/equip> ;
   owl:imports <urn:nawi-water-ontology/processtypes> ;
   owl:imports <urn:nawi-water-ontology/substances> ;


### PR DESCRIPTION
This pull request updates the ontology configuration in `water/ontology.ttl` to use newer versions of certain imported vocabularies and adds an additional import for enumeration kinds. These changes help keep the ontology up-to-date and extend its capabilities.

Ontology import updates:

* Updated QUDT vocabulary imports to use version 3.2.1 for both `unit` and `quantitykind`, replacing the previous 3.1.1 versions.
* Added an import for `urn:nawi-water-ontology/enumerationkinds` to the ontology, expanding its reference set.