### PR TITLE
Moving validation to shifty and fixing errors

### DIFF
--- a/examples/aggregation-organics-sensor.ttl
+++ b/examples/aggregation-organics-sensor.ttl
@@ -42,7 +42,7 @@
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance watr:Constituent-Organics ;
     watr:hasTemporalResolution :rolling_window_24h ;
-    watr:hasAggregation watr:Aggregate-Max ;
+    watr:hasAggregation watr:Aggregation-Max ;
     qudt:hasQuantityKind quantitykind:MassConcentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
 .

--- a/examples/brine-composition.ttl
+++ b/examples/brine-composition.ttl
@@ -1,7 +1,11 @@
 @prefix : <urn:example/brine-composition#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix s223: <http://data.ashrae.org/standard223#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix watr: <urn:nawi-water-ontology#> .
 
 <urn:example/brine-composition>

--- a/examples/percentile-organics-sensor.ttl
+++ b/examples/percentile-organics-sensor.ttl
@@ -48,9 +48,7 @@
 .
 
 :Percentile-95
-    a watr:Class ;
-    a :Percentile-95 ;
-    rdfs:subClassOf watr:Aggregation-Percentile ;
+    a watr:Aggregation-Percentile ;
     rdfs:label "95th Percentile" ;
 .
 

--- a/examples/percentile-organics-sensor.ttl
+++ b/examples/percentile-organics-sensor.ttl
@@ -1,4 +1,4 @@
-@prefix : <urn:nawi-water-ontology/examples/aggregation-organics-sensor#> .
+@prefix : <urn:nawi-water-ontology/examples/percentile-organics-sensor#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -7,11 +7,11 @@
 @prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix watr: <urn:nawi-water-ontology#> .
 
-<urn:nawi-water-ontology/examples/aggregation-organics-sensor>
+<urn:nawi-water-ontology/examples/percentile-organics-sensor>
     a owl:Ontology ;
     owl:imports <urn:nawi-water-ontology> ;
-    rdfs:label "Aggregation Property Example" ;
-    rdfs:comment "Example of a sensor observing an organics concentration property with a water-specific aggregation marker on the property." ;
+    rdfs:label "Percentile Aggregation Property Example" ;
+    rdfs:comment "Example of a sensor observing an organics concentration property with a 95th-percentile aggregation marker on the derived property." ;
 .
 
 :sample_location
@@ -31,7 +31,7 @@
     rdfs:label "Organics Concentration" ;
     s223:ofMedium s223:Fluid-Water ;
     s223:ofSubstance watr:Constituent-Organics ;
-    watr:hasProcessedData :organics_daily_max ;
+    watr:hasProcessedData :organics_95th_percentile ;
     qudt:hasQuantityKind quantitykind:MassConcentration ;
     qudt:hasUnit unit:MilliGM-PER-L ;
 .
@@ -49,12 +49,9 @@
 
 :Percentile-95
     a watr:Class ;
-    # Should we keep punning? Should it just be a subclass of watr:Aggregation-Percentile?
     a :Percentile-95 ;
     rdfs:subClassOf watr:Aggregation-Percentile ;
     rdfs:label "95th Percentile" ;
-    s223:hasValue 95 ;
-    qudt:hasUnit unit:PERCENT ;
 .
 
 :rolling_window_24h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "networkx>=3.4.2",
     "pydotplus>=2.0.2",
     "graphviz>=0.21",
+    "pyshifty>=0.2.4",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.11"
 dependencies = [
     "pyontoenv>=0.5.3",
     "rdflib>=7.0.0",
-    "buildingmotif[topquadrant]",
     "brick-tq-shacl==0.4.0a7",
     "jupyterlab>=4.2.5",
     "jupyterlab-rise>=0.42.0",

--- a/scripts/compile-water-ontology.py
+++ b/scripts/compile-water-ontology.py
@@ -1,6 +1,4 @@
 import rdflib
-from brick_tq_shacl import validate, infer
-import pyshacl
 import sys
 import ontoenv
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,10 +79,6 @@ def ontology_shapes_graph(water_graph: Graph) -> Graph:
     )
     env.update(all=True)
     shapes_graph, _imported = env.get_dependencies(water_graph, fetch_missing=True)
-    # get_dependencies only returns ontologies reached via an owl:imports triple;
-    # water_graph is the import root itself (nothing imports it), so its own
-    # triples (e.g. water/ontology.ttl's `watr:Class rdfs:subClassOf rdfs:Class`,
-    # which makes implicit SHACL class-targeting work at all) must be added back.
     shapes_graph += water_graph
     return shapes_graph
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from brick_tq_shacl import validate
+import shifty
 from ontoenv import OntoEnv
 from rdflib import Graph, Namespace
 
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES_DIR = ROOT / "examples"
 NONCONFORMING_EXAMPLES_DIR = EXAMPLES_DIR / "nonconforming"
 WATER_DIR = ROOT / "water"
+S223_DIR = ROOT / "s223"
 
 
 def _ttl_files(directory: Path) -> list[Path]:
@@ -63,7 +64,7 @@ def _ontology_closure_for_example(example_graph: Graph) -> tuple[Graph, list[str
     env = OntoEnv(
         path=ROOT,
         recreate=True,
-        search_directories=[str(WATER_DIR)],
+        search_directories=[str(WATER_DIR), str(S223_DIR)],
         includes=["*.ttl"],
     )
     env.update(all=True)
@@ -74,10 +75,9 @@ def _validation_result(example_file: Path) -> dict:
     """Validate one example graph and return the SHACL result payload."""
     data_graph = Graph().parse(example_file)
     ontology_shapes_graph, imported = _ontology_closure_for_example(data_graph)
-    valid, report_graph, report_string = validate(
+    valid, report_graph, report_string = shifty.validate(
         data_graph,
-        shape_graphs=ontology_shapes_graph,
-        min_iterations=5,
+        shacl_graph=ontology_shapes_graph,
     )
     return {
         "valid": valid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,8 +59,18 @@ def _has_example_violations(data_graph: Graph, report_graph: Graph) -> bool:
     return False
 
 
-def _ontology_closure_for_example(example_graph: Graph) -> tuple[Graph, list[str]]:
-    """Resolve an example graph's imports into a dedicated closure graph."""
+@pytest.fixture(scope="session")
+def water_graph() -> Graph:
+    """Parse the water ontology's own Turtle files, merged, once per session."""
+    g = Graph()
+    for path in sorted(WATER_DIR.glob("*.ttl")):
+        g.parse(path, format="ttl")
+    return g
+
+
+@pytest.fixture(scope="session")
+def ontology_shapes_graph(water_graph: Graph) -> Graph:
+    """Resolve the water ontology's full import closure once per session."""
     env = OntoEnv(
         path=ROOT,
         recreate=True,
@@ -68,13 +78,18 @@ def _ontology_closure_for_example(example_graph: Graph) -> tuple[Graph, list[str
         includes=["*.ttl"],
     )
     env.update(all=True)
-    return env.get_dependencies(example_graph, fetch_missing=True)
+    shapes_graph, _imported = env.get_dependencies(water_graph, fetch_missing=True)
+    # get_dependencies only returns ontologies reached via an owl:imports triple;
+    # water_graph is the import root itself (nothing imports it), so its own
+    # triples (e.g. water/ontology.ttl's `watr:Class rdfs:subClassOf rdfs:Class`,
+    # which makes implicit SHACL class-targeting work at all) must be added back.
+    shapes_graph += water_graph
+    return shapes_graph
 
 
-def _validation_result(example_file: Path) -> dict:
+def _validation_result(example_file: Path, ontology_shapes_graph: Graph) -> dict:
     """Validate one example graph and return the SHACL result payload."""
     data_graph = Graph().parse(example_file)
-    ontology_shapes_graph, imported = _ontology_closure_for_example(data_graph)
     valid, report_graph, report_string = shifty.validate(
         data_graph,
         shacl_graph=ontology_shapes_graph,
@@ -84,20 +99,21 @@ def _validation_result(example_file: Path) -> dict:
         "report_graph": report_graph,
         "report_string": report_string,
         "data_graph": data_graph,
-        "imported_ontologies": imported,
         "has_example_violations": _has_example_violations(data_graph, report_graph),
     }
 
 
 @pytest.fixture
-def example_validation_result(example_file: Path) -> dict:
+def example_validation_result(
+    example_file: Path, ontology_shapes_graph: Graph
+) -> dict:
     """Return the SHACL validation result for a conforming example."""
-    return _validation_result(example_file)
+    return _validation_result(example_file, ontology_shapes_graph)
 
 
 @pytest.fixture
 def nonconforming_example_validation_result(
-    nonconforming_example_file: Path,
+    nonconforming_example_file: Path, ontology_shapes_graph: Graph
 ) -> dict:
     """Return the SHACL validation result for a nonconforming example."""
-    return _validation_result(nonconforming_example_file)
+    return _validation_result(nonconforming_example_file, ontology_shapes_graph)

--- a/tests/test_processtype_consistency.py
+++ b/tests/test_processtype_consistency.py
@@ -26,7 +26,7 @@ from rdflib import Graph, Namespace, URIRef
 
 
 ROOT = Path(__file__).resolve().parents[1]
-WATER_TTL = ROOT / "libraries" / "water.ttl"
+WATER_DIR = ROOT / "water"
 WATR = Namespace("urn:nawi-water-ontology#")
 
 
@@ -124,7 +124,8 @@ def _find_process_class_ancestor_set(cls: URIRef, g: Graph):
 @pytest.fixture(scope="module")
 def water_graph() -> Graph:
     g = Graph()
-    g.parse(WATER_TTL, format="ttl")
+    for path in sorted(WATER_DIR.glob("*.ttl")):
+        g.parse(path, format="ttl")
     return g
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -16,8 +16,6 @@ def test_ontology_validates(water_graph: Graph, ontology_shapes_graph: Graph):
     valid, _, report_string = shifty.validate(
         water_graph,
         shacl_graph=ontology_shapes_graph,
-        # match conftest.py's examples: only sh:Violation fails the test,
-        # not sh:Warning/sh:Info (shifty's own default is "info").
         minimum_severity="violation",
     )
     print(report_string)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,32 +1,24 @@
 import logging
-from pathlib import Path
 
-import rdflib
-from ontoenv import OntoEnv
 import shifty
+from rdflib import Graph
 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-ROOT = Path(__file__).resolve().parents[1]
-WATER_DIR = ROOT / "water"
-S223_DIR = ROOT / "s223"
 
-def test_ontology_validates():
-    g = rdflib.Graph()
-    for path in sorted(WATER_DIR.glob("*.ttl")):
-        g.parse(path, format="ttl")
-    env = OntoEnv(
-        path=ROOT,
-        recreate=True,
-        search_directories=[str(WATER_DIR), str(S223_DIR)],
-        includes=["*.ttl"],
+def test_ontology_validates(water_graph: Graph, ontology_shapes_graph: Graph):
+    # Default graph_mode="union" selects focus nodes from water_graph alone
+    # (so we only validate the water ontology's own classes/shapes, not every
+    # node in the imported closure) while still evaluating constraints (e.g.
+    # sh:class checks against qudt-defined types) against the full closure.
+    valid, _, report_string = shifty.validate(
+        water_graph,
+        shacl_graph=ontology_shapes_graph,
+        # match conftest.py's examples: only sh:Violation fails the test,
+        # not sh:Warning/sh:Info (shifty's own default is "info").
+        minimum_severity="violation",
     )
-    env.update(all=True)
-    imported = env.import_dependencies(g, fetch_missing=True)
-    print(f"Imported {imported}")
-    valid, _, report_string = shifty.validate(g)
     print(report_string)
     assert valid, f"Ontology does not pass SHACL validation:\n{report_string}"
-

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,6 @@
 import logging
+from pathlib import Path
+
 import rdflib
 from ontoenv import OntoEnv
 import shifty
@@ -7,11 +9,22 @@ import shifty
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+ROOT = Path(__file__).resolve().parents[1]
+WATER_DIR = ROOT / "water"
+S223_DIR = ROOT / "s223"
+
 def test_ontology_validates():
-    env = OntoEnv(offline=False, recreate=True)
-    env.add("https://open223.info/223p.ttl")
-    g = rdflib.Graph().parse("libraries/water.ttl")
-    imported = env.import_dependencies(g)
+    g = rdflib.Graph()
+    for path in sorted(WATER_DIR.glob("*.ttl")):
+        g.parse(path, format="ttl")
+    env = OntoEnv(
+        path=ROOT,
+        recreate=True,
+        search_directories=[str(WATER_DIR), str(S223_DIR)],
+        includes=["*.ttl"],
+    )
+    env.update(all=True)
+    imported = env.import_dependencies(g, fetch_missing=True)
     print(f"Imported {imported}")
     valid, _, report_string = shifty.validate(g)
     print(report_string)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,7 @@
 import logging
 import rdflib
 from ontoenv import OntoEnv
-from brick_tq_shacl import validate
+import shifty
 
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ def test_ontology_validates():
     g = rdflib.Graph().parse("libraries/water.ttl")
     imported = env.import_dependencies(g)
     print(f"Imported {imported}")
-    valid, _, report_string = validate(g, min_iterations=5)
+    valid, _, report_string = shifty.validate(g)
     print(report_string)
     assert valid, f"Ontology does not pass SHACL validation:\n{report_string}"
 


### PR DESCRIPTION
moved validation to use shifty (which included changing some directories in the tests). 
This found some errors in the examples, which are also fixed in this branch.