### PR TITLE
scope pytest collection to tests/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ buildingmotif = { git = "https://github.com/NREL/buildingmotif.git", rev = "deve
 
 [tool.uv]
 override-dependencies = ["brick-tq-shacl==0.4.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "pyontoenv>=0.5.3",
+    "pyontoenv>=0.6.0a7",
     "rdflib>=7.0.0",
     "brick-tq-shacl==0.4.0a7",
     "jupyterlab>=4.2.5",


### PR DESCRIPTION
## Why
Running bare `uv run pytest` fails during collection because pytest discovers tests inside the gitignored `223standard/` directory (a local working copy that `.gitignore` notes "may appear when updating our copy of s223"). That directory's `tests/test_validation.py` imports `topquadrant_shacl`, which isn't installed, so collection aborts before any project tests run.

## Change
Add a `[tool.pytest.ini_options]` section to `pyproject.toml` with `testpaths = ["tests"]`, scoping discovery to the project's own `tests/` directory.

## Verification
- `uv sync` then `uv run pytest` → 8 passed (previously failed at collection with `ModuleNotFoundError: topquadrant_shacl`)