### PR TITLE
migrate to ontoenv 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 0. (to update 223, run the `download-s223.sh` script; this will only work for those with existing access to that repo)
 1. Install [`uv`](https://github.com/astral-sh/uv?tab=readme-ov-file#installation) for working with Python
 2. Install the dependencies with `uv sync`
-3. Install `ontoenv` either by downloading the latest [release](https://github.com/gtfierro/ontoenv-rs/releases) or through `cargo install ontoenv-cli@0.3.0a1`
+3. The `ontoenv` CLI (v0.6) is installed by `uv sync` as part of the `pyontoenv` dependency; run it with `uv run ontoenv`. See the [docs](https://ontoenv.gtf.fyi/) for standalone installation options.
 
 ## Building the Ontology
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "pyontoenv>=0.5.3",
+    "pyontoenv>=0.6.0",
     "rdflib>=7.0.0",
     "brick-tq-shacl==0.4.0a7",
     "jupyterlab>=4.2.5",
@@ -18,7 +18,7 @@ dependencies = [
     "networkx>=3.4.2",
     "pydotplus>=2.0.2",
     "graphviz>=0.21",
-    "pyshifty>=0.2.4",
+    "pyshifty>=0.2.7",
 ]
 
 [build-system]

--- a/scripts/compile-water-ontology.py
+++ b/scripts/compile-water-ontology.py
@@ -1,9 +1,11 @@
 import rdflib
-import sys
 import ontoenv
 
-env = ontoenv.OntoEnv()
-compiled, included = env.get_closure("urn:nawi-water-ontology", recursion_depth=1)
+with ontoenv.OntoEnv.connect(".") as env:
+    env.update()
+    compiled, included = env.copy_closure(
+        "urn:nawi-water-ontology", recursion_depth=1
+    )
 print("Included graphs:", included)
 compiled.bind("watr", rdflib.Namespace("urn:nawi-water-ontology#"))
 compiled.serialize("libraries/water.ttl")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,14 +71,14 @@ def water_graph() -> Graph:
 @pytest.fixture(scope="session")
 def ontology_shapes_graph(water_graph: Graph) -> Graph:
     """Resolve the water ontology's full import closure once per session."""
-    env = OntoEnv(
-        path=ROOT,
-        recreate=True,
+    with OntoEnv.create(
+        str(ROOT),
+        overwrite=True,
         search_directories=[str(WATER_DIR), str(S223_DIR)],
         includes=["*.ttl"],
-    )
-    env.update(all=True)
-    shapes_graph, _imported = env.get_dependencies(water_graph, fetch_missing=True)
+    ) as env:
+        env.update(force=True)
+        shapes_graph, _imported = env.get_dependencies(water_graph, fetch_missing=True)
     shapes_graph += water_graph
     return shapes_graph
 


### PR DESCRIPTION
Updates `pyontoenv` to >=0.6.0 and adapts our usage to the 0.6 API ([migration guide](https://ontoenv.gtf.fyi/migration-0.6.html)).

- `scripts/compile-water-ontology.py`: `OntoEnv()` → `OntoEnv.connect(".")` plus an explicit `update()`, and `get_closure()` → `copy_closure()` (the former now returns a read-only view).
- `tests/conftest.py`: `OntoEnv(recreate=True)` → `OntoEnv.create(overwrite=True)`, and `update(all=True)` → `update(force=True)`.
- README: the `ontoenv` CLI now comes with the `pyontoenv` dependency.

Verified: `make libraries/water.ttl` regenerates the closure and `pytest tests` passes 9/9.
