### PR TITLE
Publish compiled water ontology on GitHub Pages

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -41,12 +41,16 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --dev --pre
+      - name: Build the ontology
+        run: make
       - name: build docs
         run: |
           # need to build twice for now...
           uv run jupyter-book build docs
           uv run jupyter-book build docs
+      - name: Publish compiled ontology
+        run: cp libraries/water.ttl docs/_build/html/water.ttl
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ The purpose of this site is to provide documentation for the alpha release of th
 This site is undergoing active development for alpha release of the ontology.
 ```
 
+The compiled ontology (all files in the `water/` directory, parsed together with their imports) is available as a single Turtle file: [water.ttl](water.ttl). It is rebuilt automatically on every push to `main`.
+
 The documentation uses Diataxis[^1] as a framework for its structure, which is organized into the following sections.
 
 [^1]: https://diataxis.fr/


### PR DESCRIPTION
## Summary
- Add a "Build the ontology" step to the Pages deploy job (`make`, using the existing `ontoenv`-based `scripts/compile-water-ontology.py`) and copy the resulting `libraries/water.ttl` into `docs/_build/html/water.ttl` before it's uploaded, so the compiled graph — all files in `water/` parsed together with their `owl:imports` — is published at a stable URL on the docs site.
- Link the compiled file from the docs landing page (`docs/README.md`).

## Test plan
- [x] Ran `make libraries/water.ttl` locally to confirm the ontology still compiles (includes `urn:nawi-water-ontology`, s223 model, qudt vocab, and the local `water/` modules).
- [ ] Confirm the CI `deploy` job succeeds and `water.ttl` is reachable at the published Pages URL after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)